### PR TITLE
fix missing dependency `ptable`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/hobofan/smiles-parser"
 
 [dependencies]
 nom = "5.0.1"
-ptable = "0.3.2"
+ptable = {package = "periodic-table-on-an-enum", version = "0.3"}
 
 petgraph = { version = "0.5.0", optional = true }
 itertools = { version = "0.9.0", optional = true }


### PR DESCRIPTION
Since `ptable` crate was deleted, this crate no longer works